### PR TITLE
Fix: 'a bytes-like object is required' error

### DIFF
--- a/HuluSubsDownloader.py
+++ b/HuluSubsDownloader.py
@@ -67,7 +67,7 @@ class HuluSubs:
         print("-" * len("Downloading %s - %s" % (series_name, episode_number)))
         print("Downloading %s - %s" % (series_name, episode_number))
 
-        with open(file_name, "wb") as sub_file:
+        with open(file_name, "w") as sub_file:
             sub_file.write(str(smi_source))
 
         if str(self.subtitle_format).lower() in ['srt']:


### PR DESCRIPTION
Fixed error: ```TypeError: a bytes-like object is required, not 'str'```